### PR TITLE
GHC 8.6 fixes

### DIFF
--- a/src/Text/Layout/Table.hs
+++ b/src/Text/Layout/Table.hs
@@ -116,6 +116,7 @@ module Text.Layout.Table
 import qualified Control.Arrow                                   as A
 import           Data.List
 import           Data.Maybe
+import           Data.Semigroup
 import           Data.Default.Class
 import           Data.Default.Instances.Base                          ()
 

--- a/table-layout.cabal
+++ b/table-layout.cabal
@@ -76,7 +76,7 @@ library
                        MultiWayIf
   
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.8 && <4.12,
+  build-depends:       base >=4.8 && <4.13,
                        data-default-class >=0.1.1 && < 0.2,
                        data-default-instances-base ==0.1.*
 
@@ -87,7 +87,7 @@ library
 
 executable table-layout-test-styles
   main-is:             Test.hs
-  build-depends:       base >=4.8 && <4.12,
+  build-depends:       base >=4.8 && <4.13,
                        data-default-class >=0.1.1 && < 0.2,
                        data-default-instances-base ==0.1.*
   hs-source-dirs:      src


### PR DESCRIPTION
Fixes `base` bounds for GHC 8.6 and import of `Data.Semigroup` for before 8.2.