### PR TITLE
Extend upper bound on QuickCheck

### DIFF
--- a/table-layout.cabal
+++ b/table-layout.cabal
@@ -113,7 +113,7 @@ test-suite table-layout-tests
   hs-source-dirs:      test-suite, src
   main-is:             Spec.hs
   build-depends:       base >=4.8 && <4.13,
-                       QuickCheck >=2.8 && < 2.12,
+                       QuickCheck >=2.8 && < 2.13,
                        HUnit >=1.3,
                        data-default-class >=0.1.1 && < 0.2,
                        data-default-instances-base ==0.1.*,


### PR DESCRIPTION
The upper bound on QuickCheck is causing this package to be marked as broken on NixOS 19.03.