### PR TITLE
Allow Strings for TableStyle delimiters.

### DIFF
--- a/src/Test.hs
+++ b/src/Test.hs
@@ -30,6 +30,7 @@ main = putStrLn $ tableString [ column (expandUntil 30) left (charAlign ':') def
                 , asciiDoubleS
                 , asciiRoundS
                 , unicodeS
+                , withoutBorders unicodeS
                 , unicodeRoundS
                 , unicodeBoldS
                 , unicodeBoldStripedS

--- a/src/Test.hs
+++ b/src/Test.hs
@@ -27,6 +27,7 @@ main = putStrLn $ tableString [ column (expandUntil 30) left (charAlign ':') def
     bigNum    = "200300400500600.2"
     smallNum  = "4.20000000"
     styles    = [ asciiS
+                , asciiDoubleS
                 , asciiRoundS
                 , unicodeS
                 , unicodeRoundS

--- a/src/Text/Layout/Table.hs
+++ b/src/Text/Layout/Table.hs
@@ -254,14 +254,14 @@ tableLines specs TableStyle { .. } header rowGroups =
     -- Vertical content lines
     rowGroupLines = maybe concat (\seps -> intercalate [seps]) optGroupSepLine linesPerRowGroup
     linesPerRowGroup = map rowGroupToLines rowGroups
-    rowGroupToLines = map (horizontalContentLine groupV) . applyRowMods . rows
+    rowGroupToLines = map (horizontalContentLine groupL groupC groupR) . applyRowMods . rows
 
     -- Optional values for the header
     (addHeaderLines, fitHeaderIntoCMIs, realTopH, realTopL, realTopC, realTopR)
                   = case header of
         HeaderHS headerColSpecs hTitles
                ->
-            let headerLine    = horizontalContentLine headerV (zipWith ($) headerRowMods hTitles)
+            let headerLine    = horizontalContentLine headerL headerC headerR (zipWith ($) headerRowMods hTitles)
                 headerRowMods = zipWith3 headerCellModifier
                                          headerColSpecs
                                          cMSs

--- a/src/Text/Layout/Table.hs
+++ b/src/Text/Layout/Table.hs
@@ -237,9 +237,13 @@ tableLines specs TableStyle { .. } header rowGroups =
     -- Helpers for horizontal lines that will put layout characters arround and
     -- in between a row of the pre-formatted grid.
 
-    -- | Generate columns filled with 'sym'.
-    fakeColumns sym
-                  = map (`replicateCharB` sym) colWidths
+    -- | Generate columns filled with 'sym', or blank spaces if 'sym' is of width 0.
+    fakeColumns sym = map replicateSym colWidths
+      where
+        replicateSym w = concat $ replicate q sym' ++ [take r sym']
+          where
+            (q, r) = w `quotRem` l
+        (sym', l) = let l' = length sym in if l' == 0 then (" ", 1) else (sym, l')
 
     -- Horizontal seperator lines that occur in a table.
     topLine       = hLineDetail realTopH realTopL realTopC realTopR $ fakeColumns realTopH

--- a/src/Text/Layout/Table/Primitives/Table.hs
+++ b/src/Text/Layout/Table/Primitives/Table.hs
@@ -41,20 +41,12 @@ horizontalDetailLine
 horizontalDetailLine hSpace delimL delimM delimR cells = mconcat . intersperse (stringB hSpace) $
     stringB delimL : intersperse (stringB delimM) cells ++ [stringB delimR]
 
--- | A simplified version of 'hLineDetail' that will use the same delimiter
--- for everything.
-hLine
-    :: StringBuilder b
-    => String -- ^ The space characters that are used as padding.
-    -> String -- ^ The delimiter that is used for everything.
-    -> Row b -- ^ A row of builders.
-    -> b -- ^ The formatted line as a 'StringBuilder'.
-hLine hSpace delim = horizontalDetailLine hSpace delim delim delim
-
 -- | Render a line with actual content.
 horizontalContentLine
     :: StringBuilder b
-    => String -- ^ The delimiter that is used for everything.
+    => String -- ^ The delimiter that is used on the left side.
+    -> String -- ^ The delimeter that is used in between cells.
+    -> String -- ^ The delimeter that is used on the right side.
     -> Row b -- ^ A row of builders.
     -> b
-horizontalContentLine = hLine " "
+horizontalContentLine = horizontalDetailLine " "

--- a/src/Text/Layout/Table/Primitives/Table.hs
+++ b/src/Text/Layout/Table/Primitives/Table.hs
@@ -1,7 +1,11 @@
 -- | This module provides primitives for generating tables. Tables are generated
 -- line by line thus the functions in this module produce 'StringBuilder's that
 -- contain a line.
-module Text.Layout.Table.Primitives.Table where
+module Text.Layout.Table.Primitives.Table
+    ( horizontalDetailLine
+    , optHorizontalDetailLine
+    , horizontalContentLine
+    ) where
 
 import           Data.List
 
@@ -9,18 +13,33 @@ import           Text.Layout.Table.StringBuilder
 import           Text.Layout.Table.Spec.Util
 
 
--- | Draw a horizontal line that will use the delimiters around the
--- appropriately and visually separate by 'hSpace'.
-hLineDetail
+-- | Draw a horizontal line that will use the provided delimiters around
+-- the content appropriately and visually separate by 'hSpace'.
+--
+-- Return 'Nothing' if all delimiters are empty, and 'Just' otherwise.
+optHorizontalDetailLine
     :: StringBuilder b
     => String -- ^ The space characters that are used as padding.
     -> String -- ^ The delimiter that is used on the left side.
     -> String -- ^ The delimiter that is used in between cells.
-    -> String -- ^ The delimiter that is sued on the right side.
+    -> String -- ^ The delimiter that is used on the right side.
+    -> Row b -- ^ A row of builders.
+    -> Maybe b -- ^ The formatted line as a 'StringBuilder', or Nothing if all delimiters are null.
+optHorizontalDetailLine ""     ""     ""     ""     = const Nothing
+optHorizontalDetailLine hSpace delimL delimM delimR = Just . horizontalDetailLine hSpace delimL delimM delimR
+
+-- | Draw a horizontal line that will use the provided delimiters around
+-- the content appropriately and visually separate by 'hSpace'.
+horizontalDetailLine
+    :: StringBuilder b
+    => String -- ^ The space characters that are used as padding.
+    -> String -- ^ The delimiter that is used on the left side.
+    -> String -- ^ The delimiter that is used in between cells.
+    -> String -- ^ The delimiter that is used on the right side.
     -> Row b -- ^ A row of builders.
     -> b -- ^ The formatted line as a 'StringBuilder'.
-hLineDetail hSpace delimL delimM delimR cells =
-    mconcat $ intersperse (stringB hSpace) $ stringB delimL : intersperse (stringB delimM) cells ++ [stringB delimR]
+horizontalDetailLine hSpace delimL delimM delimR cells = mconcat . intersperse (stringB hSpace) $
+    stringB delimL : intersperse (stringB delimM) cells ++ [stringB delimR]
 
 -- | A simplified version of 'hLineDetail' that will use the same delimiter
 -- for everything.
@@ -30,12 +49,12 @@ hLine
     -> String -- ^ The delimiter that is used for everything.
     -> Row b -- ^ A row of builders.
     -> b -- ^ The formatted line as a 'StringBuilder'.
-hLine hSpace delim = hLineDetail hSpace delim delim delim
+hLine hSpace delim = horizontalDetailLine hSpace delim delim delim
 
 -- | Render a line with actual content.
-hLineContent
+horizontalContentLine
     :: StringBuilder b
     => String -- ^ The delimiter that is used for everything.
     -> Row b -- ^ A row of builders.
     -> b
-hLineContent = hLine " "
+horizontalContentLine = hLine " "

--- a/src/Text/Layout/Table/Primitives/Table.hs
+++ b/src/Text/Layout/Table/Primitives/Table.hs
@@ -13,21 +13,21 @@ import           Text.Layout.Table.Spec.Util
 -- appropriately and visually separate by 'hSpace'.
 hLineDetail
     :: StringBuilder b
-    => Char -- ^ The space character that is used as padding.
-    -> Char -- ^ The delimiter that is used on the left side.
-    -> Char -- ^ The delimiter that is used in between cells.
-    -> Char -- ^ The delimiter that is sued on the right side.
+    => String -- ^ The space characters that are used as padding.
+    -> String -- ^ The delimiter that is used on the left side.
+    -> String -- ^ The delimiter that is used in between cells.
+    -> String -- ^ The delimiter that is sued on the right side.
     -> Row b -- ^ A row of builders.
     -> b -- ^ The formatted line as a 'StringBuilder'.
 hLineDetail hSpace delimL delimM delimR cells =
-    mconcat $ intersperse (charB hSpace) $ charB delimL : intersperse (charB delimM) cells ++ [charB delimR]
+    mconcat $ intersperse (stringB hSpace) $ stringB delimL : intersperse (stringB delimM) cells ++ [stringB delimR]
 
 -- | A simplified version of 'hLineDetail' that will use the same delimiter
 -- for everything.
 hLine
     :: StringBuilder b
-    => Char -- ^ The space character that is used as padding.
-    -> Char -- ^ The delimiter that is used for everything.
+    => String -- ^ The space characters that are used as padding.
+    -> String -- ^ The delimiter that is used for everything.
     -> Row b -- ^ A row of builders.
     -> b -- ^ The formatted line as a 'StringBuilder'.
 hLine hSpace delim = hLineDetail hSpace delim delim delim
@@ -35,7 +35,7 @@ hLine hSpace delim = hLineDetail hSpace delim delim delim
 -- | Render a line with actual content.
 hLineContent
     :: StringBuilder b
-    => Char -- ^ The delimiter that is used for everything.
+    => String -- ^ The delimiter that is used for everything.
     -> Row b -- ^ A row of builders.
     -> b
-hLineContent = hLine ' '
+hLineContent = hLine " "

--- a/src/Text/Layout/Table/Style.hs
+++ b/src/Text/Layout/Table/Style.hs
@@ -13,8 +13,12 @@ data TableStyle = TableStyle
                 , headerTopR   :: String
                 , headerTopC   :: String
                 , headerTopH   :: String
-                , headerV      :: String
-                , groupV       :: String
+                , headerL      :: String
+                , headerR      :: String
+                , headerC      :: String
+                , groupL       :: String
+                , groupR       :: String
+                , groupC       :: String
                 , groupSepH    :: String
                 , groupSepC    :: String
                 , groupSepLC   :: String
@@ -29,6 +33,32 @@ data TableStyle = TableStyle
                 , groupBottomH :: String
                 }
 
+-- | Remove the top, bottom, left, and right borders from a 'TableStyle'.
+withoutBorders :: TableStyle -> TableStyle
+withoutBorders = withoutTopBorder . withoutBottomBorder . withoutLeftBorder . withoutRightBorder
+
+-- | Remove the top border from a 'TableStyle'.
+withoutTopBorder :: TableStyle -> TableStyle
+withoutTopBorder ts = ts { headerTopL = "", headerTopR = "", headerTopC = "", headerTopH = ""
+                         , groupTopL = "", groupTopR = "", groupTopC = "", groupTopH = ""
+                         }
+
+-- | Remove the bottom border from a 'TableStyle'.
+withoutBottomBorder :: TableStyle -> TableStyle
+withoutBottomBorder ts = ts { groupBottomC = "", groupBottomL = "", groupBottomR = "", groupBottomH = "" }
+
+-- | Remove the left border from a 'TableStyle'.
+withoutLeftBorder :: TableStyle -> TableStyle
+withoutLeftBorder ts = ts { headerTopL = "", headerSepLC = "", headerL = ""
+                          , groupL = "", groupSepLC = "", groupTopL = "", groupBottomL = ""
+                          }
+
+-- | Remove the right border from a 'TableStyle'.
+withoutRightBorder :: TableStyle -> TableStyle
+withoutRightBorder ts = ts { headerTopR = "", headerSepRC = "", headerR = ""
+                           , groupR = "", groupSepRC = "", groupTopR = "", groupBottomR = ""
+                           }
+
 -- | My usual ASCII table style.
 asciiRoundS :: TableStyle
 asciiRoundS = TableStyle
@@ -40,8 +70,12 @@ asciiRoundS = TableStyle
             , headerTopR   = "."
             , headerTopC   = "."
             , headerTopH   = "-"
-            , headerV      = "|"
-            , groupV       = "|"
+            , headerL      = "|"
+            , headerR      = "|"
+            , headerC      = "|"
+            , groupL       = "|"
+            , groupR       = "|"
+            , groupC       = "|"
             , groupSepH    = "-"
             , groupSepC    = "+"
             , groupSepLC   = ":"
@@ -67,8 +101,12 @@ asciiS = TableStyle
        , headerTopR   = "+"
        , headerTopC   = "+"
        , headerTopH   = "-"
-       , headerV      = "|"
-       , groupV       = "|"
+       , headerL      = "|"
+       , headerR      = "|"
+       , headerC      = "|"
+       , groupL       = "|"
+       , groupR       = "|"
+       , groupC       = "|"
        , groupSepH    = "-"
        , groupSepC    = "+"
        , groupSepLC   = "+"
@@ -94,8 +132,12 @@ asciiDoubleS = TableStyle
              , headerTopR   = "++"
              , headerTopC   = "++"
              , headerTopH   = "-"
-             , headerV      = "||"
-             , groupV       = "||"
+             , headerL      = "||"
+             , headerR      = "||"
+             , headerC      = "||"
+             , groupL       = "||"
+             , groupR       = "||"
+             , groupC       = "||"
              , groupSepH    = "-"
              , groupSepC    = "++"
              , groupSepLC   = "++"
@@ -121,8 +163,12 @@ unicodeS = TableStyle
          , headerTopR   = "┐"
          , headerTopC   = "┬"
          , headerTopH   = "─"
-         , headerV      = "│"
-         , groupV       = "│"
+         , headerL      = "│"
+         , headerR      = "│"
+         , headerC      = "│"
+         , groupL       = "│"
+         , groupR       = "│"
+         , groupC       = "│"
          , groupSepH    = "─"
          , groupSepC    = "┼"
          , groupSepLC   = "├"
@@ -148,7 +194,9 @@ unicodeBoldHeaderS = unicodeS
                    , headerTopR  = "┓"
                    , headerTopC  = "┳"
                    , headerTopH  = "━"
-                   , headerV     = "┃"
+                   , headerL     = "┃"
+                   , headerR     = "┃"
+                   , headerC     = "┃"
                    }
 
 -- | Same as 'unicodeS' but uses round edges.
@@ -178,8 +226,12 @@ unicodeBoldS = TableStyle
              , headerTopR   = "┓"
              , headerTopC   = "┳"
              , headerTopH   = "━"
-             , headerV      = "┃"
-             , groupV       = "┃"
+             , headerL      = "┃"
+             , headerR      = "┃"
+             , headerC      = "┃"
+             , groupL       = "┃"
+             , groupR       = "┃"
+             , groupC       = "┃"
              , groupSepH    = "━"
              , groupSepC    = "╋"
              , groupSepLC   = "┣"
@@ -209,8 +261,12 @@ unicodeDoubleFrameS = TableStyle
                     , headerTopR   = "╗"
                     , headerTopC   = "╦"
                     , headerTopH   = "═"
-                    , headerV      = "║"
-                    , groupV       = "║"
+                    , headerL      = "║"
+                    , headerR      = "║"
+                    , headerC      = "║"
+                    , groupL       = "║"
+                    , groupR       = "║"
+                    , groupC       = "║"
                     , groupSepH    = "═"
                     , groupSepC    = "╬"
                     , groupSepLC   = "╠"

--- a/src/Text/Layout/Table/Style.hs
+++ b/src/Text/Layout/Table/Style.hs
@@ -83,6 +83,33 @@ asciiS = TableStyle
        , groupBottomH = "-"
        }
 
+-- | Like 'asciiS', but uses double lines and double pluses for the header joints.
+asciiDoubleS :: TableStyle
+asciiDoubleS = TableStyle
+             { headerSepH   = "-"
+             , headerSepLC  = "++"
+             , headerSepRC  = "++"
+             , headerSepC   = "++"
+             , headerTopL   = "++"
+             , headerTopR   = "++"
+             , headerTopC   = "++"
+             , headerTopH   = "-"
+             , headerV      = "||"
+             , groupV       = "||"
+             , groupSepH    = "-"
+             , groupSepC    = "++"
+             , groupSepLC   = "++"
+             , groupSepRC   = "++"
+             , groupTopC    = "++"
+             , groupTopL    = "++"
+             , groupTopR    = "++"
+             , groupTopH    = "-"
+             , groupBottomC = "++"
+             , groupBottomL = "++"
+             , groupBottomR = "++"
+             , groupBottomH = "-"
+             }
+
 -- | Uses special unicode characters to draw clean thin boxes.
 unicodeS :: TableStyle
 unicodeS = TableStyle

--- a/src/Text/Layout/Table/Style.hs
+++ b/src/Text/Layout/Table/Style.hs
@@ -5,123 +5,123 @@ module Text.Layout.Table.Style where
 -- | Specifies the different letters to construct the non-content structure of a
 -- table.
 data TableStyle = TableStyle
-                { headerSepH   :: Char
-                , headerSepLC  :: Char
-                , headerSepRC  :: Char
-                , headerSepC   :: Char
-                , headerTopL   :: Char
-                , headerTopR   :: Char
-                , headerTopC   :: Char
-                , headerTopH   :: Char
-                , headerV      :: Char
-                , groupV       :: Char
-                , groupSepH    :: Char
-                , groupSepC    :: Char
-                , groupSepLC   :: Char
-                , groupSepRC   :: Char
-                , groupTopC    :: Char
-                , groupTopL    :: Char
-                , groupTopR    :: Char
-                , groupTopH    :: Char
-                , groupBottomC :: Char
-                , groupBottomL :: Char
-                , groupBottomR :: Char
-                , groupBottomH :: Char
+                { headerSepH   :: String
+                , headerSepLC  :: String
+                , headerSepRC  :: String
+                , headerSepC   :: String
+                , headerTopL   :: String
+                , headerTopR   :: String
+                , headerTopC   :: String
+                , headerTopH   :: String
+                , headerV      :: String
+                , groupV       :: String
+                , groupSepH    :: String
+                , groupSepC    :: String
+                , groupSepLC   :: String
+                , groupSepRC   :: String
+                , groupTopC    :: String
+                , groupTopL    :: String
+                , groupTopR    :: String
+                , groupTopH    :: String
+                , groupBottomC :: String
+                , groupBottomL :: String
+                , groupBottomR :: String
+                , groupBottomH :: String
                 }
 
 -- | My usual ASCII table style.
 asciiRoundS :: TableStyle
-asciiRoundS = TableStyle 
-            { headerSepH   = '='
-            , headerSepLC  = ':'
-            , headerSepRC  = ':'
-            , headerSepC   = ':'
-            , headerTopL   = '.'
-            , headerTopR   = '.'
-            , headerTopC   = '.'
-            , headerTopH   = '-'
-            , headerV      = '|'
-            , groupV       = '|'
-            , groupSepH    = '-'
-            , groupSepC    = '+'
-            , groupSepLC   = ':'
-            , groupSepRC   = ':'
-            , groupTopC    = '.'
-            , groupTopL    = '.'
-            , groupTopR    = '.'
-            , groupTopH    = '-'
-            , groupBottomC = '\''
-            , groupBottomL = '\''
-            , groupBottomR = '\''
-            , groupBottomH = '-'
+asciiRoundS = TableStyle
+            { headerSepH   = "="
+            , headerSepLC  = ":"
+            , headerSepRC  = ":"
+            , headerSepC   = ":"
+            , headerTopL   = "."
+            , headerTopR   = "."
+            , headerTopC   = "."
+            , headerTopH   = "-"
+            , headerV      = "|"
+            , groupV       = "|"
+            , groupSepH    = "-"
+            , groupSepC    = "+"
+            , groupSepLC   = ":"
+            , groupSepRC   = ":"
+            , groupTopC    = "."
+            , groupTopL    = "."
+            , groupTopR    = "."
+            , groupTopH    = "-"
+            , groupBottomC = "\'"
+            , groupBottomL = "\'"
+            , groupBottomR = "\'"
+            , groupBottomH = "-"
             }
 
 -- | Uses lines and plus for joints.
 asciiS :: TableStyle
 asciiS = TableStyle
-       { headerSepH   = '-'
-       , headerSepLC  = '+'
-       , headerSepRC  = '+'
-       , headerSepC   = '+'
-       , headerTopL   = '+'
-       , headerTopR   = '+'
-       , headerTopC   = '+'
-       , headerTopH   = '-'
-       , headerV      = '|'
-       , groupV       = '|'
-       , groupSepH    = '-'
-       , groupSepC    = '+'
-       , groupSepLC   = '+'
-       , groupSepRC   = '+'
-       , groupTopC    = '+'
-       , groupTopL    = '+'
-       , groupTopR    = '+'
-       , groupTopH    = '-'
-       , groupBottomC = '+'
-       , groupBottomL = '+'
-       , groupBottomR = '+'
-       , groupBottomH = '-'
+       { headerSepH   = "-"
+       , headerSepLC  = "+"
+       , headerSepRC  = "+"
+       , headerSepC   = "+"
+       , headerTopL   = "+"
+       , headerTopR   = "+"
+       , headerTopC   = "+"
+       , headerTopH   = "-"
+       , headerV      = "|"
+       , groupV       = "|"
+       , groupSepH    = "-"
+       , groupSepC    = "+"
+       , groupSepLC   = "+"
+       , groupSepRC   = "+"
+       , groupTopC    = "+"
+       , groupTopL    = "+"
+       , groupTopR    = "+"
+       , groupTopH    = "-"
+       , groupBottomC = "+"
+       , groupBottomL = "+"
+       , groupBottomR = "+"
+       , groupBottomH = "-"
        }
 
--- | Uses special unicode characters to draw clean thin boxes. 
+-- | Uses special unicode characters to draw clean thin boxes.
 unicodeS :: TableStyle
 unicodeS = TableStyle
-         { headerSepH   = '═'
-         , headerSepLC  = '╞'
-         , headerSepRC  = '╡'
-         , headerSepC   = '╪'
-         , headerTopL   = '┌'
-         , headerTopR   = '┐'
-         , headerTopC   = '┬'
-         , headerTopH   = '─'
-         , headerV      = '│'
-         , groupV       = '│'
-         , groupSepH    = '─'
-         , groupSepC    = '┼'
-         , groupSepLC   = '├'
-         , groupSepRC   = '┤'
-         , groupTopC    = '┬'
-         , groupTopL    = '┌'
-         , groupTopR    = '┐'
-         , groupTopH    = '─'
-         , groupBottomC = '┴'
-         , groupBottomL = '└'
-         , groupBottomR = '┘'
-         , groupBottomH = '─'
+         { headerSepH   = "═"
+         , headerSepLC  = "╞"
+         , headerSepRC  = "╡"
+         , headerSepC   = "╪"
+         , headerTopL   = "┌"
+         , headerTopR   = "┐"
+         , headerTopC   = "┬"
+         , headerTopH   = "─"
+         , headerV      = "│"
+         , groupV       = "│"
+         , groupSepH    = "─"
+         , groupSepC    = "┼"
+         , groupSepLC   = "├"
+         , groupSepRC   = "┤"
+         , groupTopC    = "┬"
+         , groupTopL    = "┌"
+         , groupTopR    = "┐"
+         , groupTopH    = "─"
+         , groupBottomC = "┴"
+         , groupBottomL = "└"
+         , groupBottomR = "┘"
+         , groupBottomH = "─"
          }
 
 -- | Same as 'unicodeS' but uses bold headers.
 unicodeBoldHeaderS :: TableStyle
 unicodeBoldHeaderS = unicodeS
-                   { headerSepH  = '━'
-                   , headerSepLC = '┡'
-                   , headerSepRC = '┩'
-                   , headerSepC  = '╇'
-                   , headerTopL  = '┏'
-                   , headerTopR  = '┓'
-                   , headerTopC  = '┳'
-                   , headerTopH  = '━'
-                   , headerV     = '┃'
+                   { headerSepH  = "━"
+                   , headerSepLC = "┡"
+                   , headerSepRC = "┩"
+                   , headerSepC  = "╇"
+                   , headerTopL  = "┏"
+                   , headerTopR  = "┓"
+                   , headerTopC  = "┳"
+                   , headerTopH  = "━"
+                   , headerV     = "┃"
                    }
 
 -- | Same as 'unicodeS' but uses round edges.
@@ -135,65 +135,65 @@ unicodeRoundS = unicodeS
               , headerTopR   = roundedTR
               }
   where
-    roundedTL = '╭'
-    roundedTR = '╮'
-    roundedBL = '╰'
-    roundedBR = '╯'
+    roundedTL = "╭"
+    roundedTR = "╮"
+    roundedBL = "╰"
+    roundedBR = "╯"
 
 -- | Uses bold lines.
 unicodeBoldS :: TableStyle
 unicodeBoldS = TableStyle
-             { headerSepH   = '━'
-             , headerSepLC  = '┣'
-             , headerSepRC  = '┫'
-             , headerSepC   = '╋'
-             , headerTopL   = '┏'
-             , headerTopR   = '┓'
-             , headerTopC   = '┳'
-             , headerTopH   = '━'
-             , headerV      = '┃'
-             , groupV       = '┃'
-             , groupSepH    = '━'
-             , groupSepC    = '╋'
-             , groupSepLC   = '┣'
-             , groupSepRC   = '┫'
-             , groupTopC    = '┳'
-             , groupTopL    = '┏'
-             , groupTopR    = '┓'
-             , groupTopH    = '━'
-             , groupBottomC = '┻'
-             , groupBottomL = '┗'
-             , groupBottomR = '┛'
-             , groupBottomH = '━'
+             { headerSepH   = "━"
+             , headerSepLC  = "┣"
+             , headerSepRC  = "┫"
+             , headerSepC   = "╋"
+             , headerTopL   = "┏"
+             , headerTopR   = "┓"
+             , headerTopC   = "┳"
+             , headerTopH   = "━"
+             , headerV      = "┃"
+             , groupV       = "┃"
+             , groupSepH    = "━"
+             , groupSepC    = "╋"
+             , groupSepLC   = "┣"
+             , groupSepRC   = "┫"
+             , groupTopC    = "┳"
+             , groupTopL    = "┏"
+             , groupTopR    = "┓"
+             , groupTopH    = "━"
+             , groupBottomC = "┻"
+             , groupBottomL = "┗"
+             , groupBottomR = "┛"
+             , groupBottomH = "━"
              }
 
 -- | Uses bold lines with exception of group seperators, which are striped slim.
 unicodeBoldStripedS :: TableStyle
-unicodeBoldStripedS = unicodeBoldS { groupSepH = '-', groupSepC = '┃', groupSepLC = '┃', groupSepRC = '┃' }
+unicodeBoldStripedS = unicodeBoldS { groupSepH = "-", groupSepC = "┃", groupSepLC = "┃", groupSepRC = "┃" }
 
 -- | Draw every line with a double frame.
 unicodeDoubleFrameS :: TableStyle
 unicodeDoubleFrameS = TableStyle
-                    { headerSepH   = '═'
-                    , headerSepLC  = '╠'
-                    , headerSepRC  = '╣'
-                    , headerSepC   = '╬'
-                    , headerTopL   = '╔'
-                    , headerTopR   = '╗'
-                    , headerTopC   = '╦'
-                    , headerTopH   = '═'
-                    , headerV      = '║'
-                    , groupV       = '║'
-                    , groupSepH    = '═'
-                    , groupSepC    = '╬'
-                    , groupSepLC   = '╠'
-                    , groupSepRC   = '╣'
-                    , groupTopC    = '╦'
-                    , groupTopL    = '╔'
-                    , groupTopR    = '╗'
-                    , groupTopH    = '═'
-                    , groupBottomC = '╩'
-                    , groupBottomL = '╚'
-                    , groupBottomR = '╝'
-                    , groupBottomH = '═'
+                    { headerSepH   = "═"
+                    , headerSepLC  = "╠"
+                    , headerSepRC  = "╣"
+                    , headerSepC   = "╬"
+                    , headerTopL   = "╔"
+                    , headerTopR   = "╗"
+                    , headerTopC   = "╦"
+                    , headerTopH   = "═"
+                    , headerV      = "║"
+                    , groupV       = "║"
+                    , groupSepH    = "═"
+                    , groupSepC    = "╬"
+                    , groupSepLC   = "╠"
+                    , groupSepRC   = "╣"
+                    , groupTopC    = "╦"
+                    , groupTopL    = "╔"
+                    , groupTopR    = "╗"
+                    , groupTopH    = "═"
+                    , groupBottomC = "╩"
+                    , groupBottomL = "╚"
+                    , groupBottomR = "╝"
+                    , groupBottomH = "═"
                     }


### PR DESCRIPTION
Fixes #17.

This allows a greater range of delimiters allowed in tables, including multi-character delimiters like `||`, or null delimiters `""`. This furthermore allows us to create tables with no outer borders.

Here are two examples of new table styles created with this.

Using `asciiDoubleS`:
```
├────────────────────────────┼───────────────────────────────────────────────────────────────────┤
│                            │        ++-------------------++-------------------++-----++        │
│  len spec: expand          │        ||     Some text     ||   Some numbers    ||  X  ||        │
│  position: left            │        ++-------------------++-------------------++-----++        │
│ alignment: no align        │        || This is long text || 4.20000000        || foo ||        │
│                            │        || Short             || 200300400500600.2 || bar ||        │
│                            │        ++-------------------++-------------------++-----++        │
├────────────────────────────┼───────────────────────────────────────────────────────────────────┤
```

Using `withoutBorders unicodeS`:
```
├────────────────────────────┼───────────────────────────────────────────────────────────────────┤
│  len spec: expand          │                Some text     │   Some numbers    │  X             │
│  position: left            │           ═══════════════════╪═══════════════════╪═════           │
│ alignment: no align        │            This is long text │ 4.20000000        │ foo            │
│                            │            Short             │ 200300400500600.2 │ bar            │
├────────────────────────────┼───────────────────────────────────────────────────────────────────┤

```