### PR TITLE
Minor cleanups and efficiency improvements.

### DIFF
--- a/src/Text/Layout/Table/Cell.hs
+++ b/src/Text/Layout/Table/Cell.hs
@@ -41,7 +41,7 @@ class Cell a where
 
 instance Cell String where
     dropLeft = drop
-    dropRight n = reverse . drop n . reverse
+    dropRight n s = zipWith const s (drop n s)
     visibleLength = length
     measureAlignment p xs = case break p xs of
         (ls, rs) -> AlignInfo (length ls) $ case rs of

--- a/src/Text/Layout/Table/StringBuilder.hs
+++ b/src/Text/Layout/Table/StringBuilder.hs
@@ -30,5 +30,4 @@ instance StringBuilder String where
 instance StringBuilder (Endo String) where
     stringB = diff
     charB = Endo . (:)
-    replicateCharB i c = Endo $ \s -> foldr ($) s $ replicate i (c :) 
-
+    replicateCharB i c = stimesMonoid i (Endo (c :))


### PR DESCRIPTION
Avoid reversing strings twice.