### PR TITLE
Add WideString and WideText.

### DIFF
--- a/src/Text/Layout/Table/Cell.hs
+++ b/src/Text/Layout/Table/Cell.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE FlexibleInstances #-}
 module Text.Layout.Table.Cell where
 
+import qualified Data.Text as T
+
 import Text.Layout.Table.Primitives.AlignInfo
 import Text.Layout.Table.Spec.CutMark
 import Text.Layout.Table.Spec.OccSpec
@@ -49,6 +51,17 @@ instance Cell String where
             _ : rs' -> Just $ length rs'
 
     buildCell = stringB
+
+instance Cell T.Text where
+    dropLeft = T.drop
+    dropRight = T.dropEnd
+    visibleLength = T.length
+    measureAlignment p xs = case T.break p xs of
+        (ls, rs) -> AlignInfo (T.length ls) $ if T.null rs
+            then Nothing
+            else Just $ T.length rs - 1
+
+    buildCell = textB
 
 remSpacesB :: (Cell a, StringBuilder b) => Int -> a -> b
 remSpacesB n c = remSpacesB' n $ visibleLength c

--- a/src/Text/Layout/Table/Cell/WideString.hs
+++ b/src/Text/Layout/Table/Cell/WideString.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+module Text.Layout.Table.Cell.WideString
+    ( WideString(..)
+    ) where
+
+import Data.String
+import Text.DocLayout
+
+import Text.Layout.Table.Cell
+import Text.Layout.Table.Primitives.AlignInfo
+import Text.Layout.Table.StringBuilder
+
+-- | A newtype for String in which characters can be wider than one space.
+newtype WideString = WideString String
+    deriving (Eq, Ord, Show, Read, Semigroup, Monoid, IsString)
+
+instance Cell WideString where
+    dropLeft i (WideString s) = WideString $ dropWide True i s
+    dropRight i (WideString s) = WideString . reverse . dropWide False i $ reverse s
+    visibleLength (WideString s) = realLength s
+    measureAlignment p (WideString s) = measureAlignmentWide p s
+    buildCell (WideString s) = buildCell s
+
+-- | Drop characters from the left side of a 'String' until at least the
+-- provided width has been removed.
+--
+-- The provided `Bool` determines whether to continue dropping zero-width
+-- characters after the requested width has been dropped.
+dropWide :: Bool -> Int -> String -> String
+dropWide _ i [] = []
+dropWide gobbleZeroWidth i l@(x : xs)
+    | gobbleZeroWidth && i == 0 && charLen == 0 = dropWide gobbleZeroWidth i xs
+    | i <= 0       = l
+    | charLen <= i = dropWide gobbleZeroWidth (i - charLen) xs
+    | otherwise    = replicate (charLen - i) ' ' ++ dropWide gobbleZeroWidth 0 xs
+  where
+    charLen = charWidth x
+
+measureAlignmentWide :: (Char -> Bool) -> String -> AlignInfo
+measureAlignmentWide p xs = case break p xs of
+    (ls, rs) -> AlignInfo (realLength ls) $ case rs of
+        []      -> Nothing
+        _ : rs' -> Just $ realLength rs'

--- a/src/Text/Layout/Table/Cell/WideString.hs
+++ b/src/Text/Layout/Table/Cell/WideString.hs
@@ -1,9 +1,13 @@
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE MultiWayIf                 #-}
+{-# LANGUAGE OverloadedStrings          #-}
 module Text.Layout.Table.Cell.WideString
     ( WideString(..)
+    , WideText(..)
     ) where
 
 import Data.String
+import qualified Data.Text as T
 import Text.DocLayout
 
 import Text.Layout.Table.Cell
@@ -41,3 +45,37 @@ measureAlignmentWide p xs = case break p xs of
     (ls, rs) -> AlignInfo (realLength ls) $ case rs of
         []      -> Nothing
         _ : rs' -> Just $ realLength rs'
+
+-- | A newtype for Text in which characters can be wider than one space.
+newtype WideText = WideText T.Text
+    deriving (Eq, Ord, Show, Read, Semigroup, Monoid, IsString)
+
+instance Cell WideText where
+    dropLeft i (WideText s) = WideText $ dropLeftWideT i s
+    dropRight i (WideText s) = WideText $ dropRightWideT i s
+    visibleLength (WideText s) = realLength s
+    measureAlignment p (WideText s) = measureAlignmentWideT p s
+    buildCell (WideText s) = buildCell s
+
+dropLeftWideT :: Int -> T.Text -> T.Text
+dropLeftWideT i txt = case T.uncons txt of
+    Nothing -> txt
+    Just (x, xs) -> let l = charWidth x in if
+        | i == 0 && l == 0 -> dropLeftWideT i xs
+        | i <= 0    -> txt
+        | l <= i    -> dropLeftWideT (i - l) xs
+        | otherwise -> T.replicate (l - i) " " <> dropLeftWideT 0 xs
+
+dropRightWideT :: Int -> T.Text -> T.Text
+dropRightWideT i txt = case T.unsnoc txt of
+    Nothing -> txt
+    Just (xs, x) -> let l = charWidth x in if
+        | i <= 0    -> txt
+        | l <= i    -> dropRightWideT (i - l) xs
+        | otherwise -> xs <> T.replicate (l - i) " "
+
+measureAlignmentWideT :: (Char -> Bool) -> T.Text -> AlignInfo
+measureAlignmentWideT p xs = case T.break p xs of
+    (ls, rs) -> AlignInfo (realLength ls) $ if T.null rs
+        then Nothing
+        else Just . realLength $ T.drop 1 rs

--- a/src/Text/Layout/Table/StringBuilder.hs
+++ b/src/Text/Layout/Table/StringBuilder.hs
@@ -2,6 +2,8 @@
 module Text.Layout.Table.StringBuilder where
 
 import Data.Semigroup
+import qualified Data.Text as T
+import qualified Data.Text.Lazy.Builder as TB
 
 -- | A type that is used to construct parts of a table.
 class Monoid a => StringBuilder a where
@@ -10,6 +12,10 @@ class Monoid a => StringBuilder a where
 
     -- | Create a builder with a single 'Char'.
     charB :: Char -> a
+
+    -- | Create a builder with a 'Text'.
+    textB :: T.Text -> a
+    textB = stringB . T.unpack
 
     -- | Create a builder with several 'Char's.
     replicateCharB :: Int -> Char -> a
@@ -31,3 +37,15 @@ instance StringBuilder (Endo String) where
     stringB = diff
     charB = Endo . (:)
     replicateCharB i c = stimesMonoid i (Endo (c :))
+
+instance StringBuilder T.Text where
+    stringB = T.pack
+    charB = T.singleton
+    textB = id
+    replicateCharB n = T.replicate n . T.singleton
+
+instance StringBuilder TB.Builder where
+    stringB = TB.fromString
+    charB = TB.singleton
+    textB = TB.fromText
+    replicateCharB n = TB.fromText . T.replicate n . T.singleton

--- a/table-layout.cabal
+++ b/table-layout.cabal
@@ -55,6 +55,7 @@ library
   exposed-modules:     Text.Layout.Table,
                        Text.Layout.Table.Cell,
                        Text.Layout.Table.Cell.Formatted,
+                       Text.Layout.Table.Cell.WideString,
                        Text.Layout.Table.Justify,
                        Text.Layout.Table.Style,
                        Text.Layout.Table.Vertical,
@@ -91,7 +92,8 @@ library
   -- Other library packages from which modules are imported.
   build-depends:       base >=4.9 && <4.15,
                        data-default-class >=0.1.1 && < 0.2,
-                       data-default-instances-base ==0.1.*
+                       data-default-instances-base ==0.1.*,
+                       doclayout >=0.3 && <0.4
 
   hs-source-dirs:      src
   
@@ -102,11 +104,13 @@ executable table-layout-test-styles
   main-is:             Test.hs
   build-depends:       base >=4.9 && <4.15,
                        data-default-class >=0.1.1 && < 0.2,
-                       data-default-instances-base ==0.1.*
+                       data-default-instances-base ==0.1.*,
+                       doclayout >=0.3 && <0.4
   hs-source-dirs:      src
   other-modules:       Text.Layout.Table,
                        Text.Layout.Table.Cell,
                        Text.Layout.Table.Cell.Formatted,
+                       Text.Layout.Table.Cell.WideString,
                        Text.Layout.Table.Justify,
                        Text.Layout.Table.Style,
                        Text.Layout.Table.Vertical
@@ -140,6 +144,7 @@ test-suite table-layout-tests
                        HUnit >=1.3,
                        data-default-class >=0.1.1 && < 0.2,
                        data-default-instances-base ==0.1.*,
+                       doclayout >=0.3 && <0.4,
                        hspec
 
   other-modules:       TestSpec,
@@ -148,6 +153,7 @@ test-suite table-layout-tests
 
                        Text.Layout.Table.Cell,
                        Text.Layout.Table.Cell.Formatted,
+                       Text.Layout.Table.Cell.WideString,
                        Text.Layout.Table.Justify,
                        Text.Layout.Table.Style,
                        Text.Layout.Table.Vertical

--- a/table-layout.cabal
+++ b/table-layout.cabal
@@ -93,7 +93,8 @@ library
   build-depends:       base >=4.9 && <4.15,
                        data-default-class >=0.1.1 && < 0.2,
                        data-default-instances-base ==0.1.*,
-                       doclayout >=0.3 && <0.4
+                       doclayout >=0.3 && <0.4,
+                       text
 
   hs-source-dirs:      src
   
@@ -105,7 +106,8 @@ executable table-layout-test-styles
   build-depends:       base >=4.9 && <4.15,
                        data-default-class >=0.1.1 && < 0.2,
                        data-default-instances-base ==0.1.*,
-                       doclayout >=0.3 && <0.4
+                       doclayout >=0.3 && <0.4,
+                       text
   hs-source-dirs:      src
   other-modules:       Text.Layout.Table,
                        Text.Layout.Table.Cell,
@@ -145,6 +147,7 @@ test-suite table-layout-tests
                        data-default-class >=0.1.1 && < 0.2,
                        data-default-instances-base ==0.1.*,
                        doclayout >=0.3 && <0.4,
+                       text,
                        hspec
 
   other-modules:       TestSpec,

--- a/test-suite/TestSpec.hs
+++ b/test-suite/TestSpec.hs
@@ -4,13 +4,15 @@ module TestSpec
 
 -- TODO idempotency of fitting CMIs
 
+import qualified Data.Text as T
+
 import Test.Hspec
 import Test.Hspec.QuickCheck
 import Test.QuickCheck
 
 import Text.Layout.Table
 import Text.Layout.Table.Cell (Cell(..), CutAction(..), CutInfo(..), applyCutInfo, determineCutAction, determineCuts, viewRange)
-import Text.Layout.Table.Cell.WideString (WideString(..))
+import Text.Layout.Table.Cell.WideString (WideString(..), WideText(..))
 import Text.Layout.Table.Spec.OccSpec
 import Text.Layout.Table.Primitives.Basic
 import Text.Layout.Table.Primitives.AlignInfo
@@ -232,6 +234,18 @@ spec = do
             describe "on narrow characters" $ do
                 it "drops a combining character for free" $ dropRight 3 narrow `shouldBe` WideString "Bien s"
                 it "does not drop a combining character without their previous" $ dropRight 2 narrow `shouldBe` WideString "Bien sû"
+
+    describe "wide text" $ do
+        describe "buildCell" $ do
+            prop "gives the same result as wide string" $ \x -> buildCell (WideText $ T.pack x) `shouldBe` x
+        describe "visibleLength" $ do
+            prop "gives the same result as wide string" $ \x -> visibleLength (WideText $ T.pack x) `shouldBe` visibleLength (WideString x)
+        describe "measureAlignment" $ do
+            prop "gives the same result as wide string" $ \x -> measureAlignment (=='e') (WideText $ T.pack x) `shouldBe` measureAlignment (=='e') (WideString x)
+        describe "dropLeft" $ do
+            prop "gives the same result as wide string" $ \(Small n) x -> buildCell (dropLeft n . WideText $ T.pack x) `shouldBe` (buildCell . dropLeft n $ WideString x :: String)
+        describe "dropRight" $ do
+            prop "gives the same result as wide string" $ \(Small n) x -> buildCell (dropRight n . WideText $ T.pack x) `shouldBe` (buildCell . dropRight n $ WideString x :: String)
   where
     customCM = doubleCutMark "<.." "..>"
     unevenCM = doubleCutMark "<" "-->"


### PR DESCRIPTION
These calculate width differently than string and text, taking into account that some characters are wider than 1 space (e.g. Han characters) and some are narrower (e.g. unicode combining characters).

Also adds some instances for Text and Text Builder.

Fixes #8.