### PR TITLE
Generalise grid, gridLines, and tableLines to produce StringBuilders.

### DIFF
--- a/src/Text/Layout/Table/Primitives/Header.hs
+++ b/src/Text/Layout/Table/Primitives/Header.hs
@@ -2,12 +2,14 @@ module Text.Layout.Table.Primitives.Header where
 
 import Data.Maybe
 
+import Text.Layout.Table.Cell
+import Text.Layout.Table.StringBuilder
 import Text.Layout.Table.Primitives.ColumnModifier
 import Text.Layout.Table.Spec.CutMark
 import Text.Layout.Table.Spec.HeaderColSpec
 
 -- | Combine a 'HeaderColSpec' and existing 'ColModInfo's to format header cells.
-headerCellModifier :: HeaderColSpec -> CutMark -> ColModInfo -> (String -> String)
+headerCellModifier :: (Cell a, StringBuilder b) => HeaderColSpec -> CutMark -> ColModInfo -> (a -> b)
 headerCellModifier (HeaderColSpec pos optCutMark) cutMark cmi =
     columnModifier pos (fromMaybe cutMark optCutMark) (unalignedCMI cmi)
 


### PR DESCRIPTION
Instead of Strings.

`gridString` and `tableString` have been left producing Strings because they have ‘String’ in their names, however it would also be reasonable to generalise these.