### PR TITLE
Remove dependency on data-default-instances-base, and bump base version

### DIFF
--- a/src/Text/Layout/Table.hs
+++ b/src/Text/Layout/Table.hs
@@ -118,7 +118,6 @@ module Text.Layout.Table
 
 import           Data.List
 import           Data.Default.Class
-import           Data.Default.Instances.Base                 ()
 
 import           Text.Layout.Table.Cell
 import           Text.Layout.Table.Justify

--- a/src/Text/Layout/Table/Spec/HeaderColSpec.hs
+++ b/src/Text/Layout/Table/Spec/HeaderColSpec.hs
@@ -1,7 +1,6 @@
 module Text.Layout.Table.Spec.HeaderColSpec where
 
 import Data.Default.Class
-import Data.Default.Instances.Base ()
 
 import Text.Layout.Table.Spec.Position
 import Text.Layout.Table.Spec.CutMark

--- a/table-layout.cabal
+++ b/table-layout.cabal
@@ -89,7 +89,7 @@ library
                        MultiWayIf
   
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.9 && <4.15,
+  build-depends:       base >=4.9 && <4.16,
                        data-default-class >=0.1.2 && < 0.2
 
   hs-source-dirs:      src
@@ -99,7 +99,7 @@ library
 
 executable table-layout-test-styles
   main-is:             Test.hs
-  build-depends:       base >=4.9 && <4.15,
+  build-depends:       base >=4.9 && <4.16,
                        data-default-class >=0.1.2 && < 0.2
   hs-source-dirs:      src
   other-modules:       Text.Layout.Table,
@@ -133,7 +133,7 @@ test-suite table-layout-tests
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test-suite, src
   main-is:             Spec.hs
-  build-depends:       base >=4.9 && <4.15,
+  build-depends:       base >=4.9 && <4.16,
                        QuickCheck >=2.8 && < 2.15,
                        HUnit >=1.3,
                        data-default-class >=0.1.2 && < 0.2,

--- a/table-layout.cabal
+++ b/table-layout.cabal
@@ -90,8 +90,7 @@ library
   
   -- Other library packages from which modules are imported.
   build-depends:       base >=4.9 && <4.15,
-                       data-default-class >=0.1.1 && < 0.2,
-                       data-default-instances-base ==0.1.*
+                       data-default-class >=0.1.2 && < 0.2
 
   hs-source-dirs:      src
   
@@ -101,8 +100,7 @@ library
 executable table-layout-test-styles
   main-is:             Test.hs
   build-depends:       base >=4.9 && <4.15,
-                       data-default-class >=0.1.1 && < 0.2,
-                       data-default-instances-base ==0.1.*
+                       data-default-class >=0.1.2 && < 0.2
   hs-source-dirs:      src
   other-modules:       Text.Layout.Table,
                        Text.Layout.Table.Cell,
@@ -138,8 +136,7 @@ test-suite table-layout-tests
   build-depends:       base >=4.9 && <4.15,
                        QuickCheck >=2.8 && < 2.15,
                        HUnit >=1.3,
-                       data-default-class >=0.1.1 && < 0.2,
-                       data-default-instances-base ==0.1.*,
+                       data-default-class >=0.1.2 && < 0.2,
                        hspec
 
   other-modules:       TestSpec,


### PR DESCRIPTION
`data-default-instances-base` is not on stackage, and this is a blocker for getting this project on stackage (see #12).

However, in 2016 `data-default-instances-base` was made a no-op which just re-exports instances from `data-default-class`, which we already depend on. It can therefore be safely removed.