### PR TITLE
Add explicit defaults for various data types

### DIFF
--- a/src/Test.hs
+++ b/src/Test.hs
@@ -12,7 +12,7 @@ inheritMyStyle = inheritStyleHeaderGroup makeLineSolid id (fst . style) (snd . s
     style TinySep  = (SingleLine, NoLine)
 
 main :: IO ()
-main = putStrLn $ tableString [ column (expandUntil 30) left (charAlign ':') def
+main = putStrLn $ tableString [ column (expandUntil 30) left (charAlign ':') ellipsisCutMark
                               , column expand center noAlign noCutMark
                               ]
                               unicodeRoundS
@@ -29,12 +29,12 @@ main = putStrLn $ tableString [ column (expandUntil 30) left (charAlign ':') def
                               s
                               (fullSepH DashLine (repeat $ headerColumn right Nothing) ["1", "Two"])
                               (groupH BigSep
-                                  [ fullSepH SmallSep (repeat def) ["Some text", "Some numbers", "X"]
+                                  [ fullSepH SmallSep (repeat defHeaderColSpec) ["Some text", "Some numbers", "X"]
                                   , groupH SmallSep
-                                      [ fullSepH TinySep (repeat def) ["Z", "W"]
-                                      , fullSepH TinySep (repeat def) ["A", "B"]
+                                      [ fullSepH TinySep (repeat defHeaderColSpec) ["Z", "W"]
+                                      , fullSepH TinySep (repeat defHeaderColSpec) ["A", "B"]
                                       ]
-                                  , fullSepH TinySep  (repeat def) ["Text", "Y"]
+                                  , fullSepH TinySep  (repeat defHeaderColSpec) ["Text", "Y"]
                                   ]
                               )
                               [ rowsG [ [longText, smallNum, "foo", "blah", "bloo", "blop", "blog", shortText, "baz"]
@@ -57,7 +57,7 @@ main = putStrLn $ tableString [ column (expandUntil 30) left (charAlign ':') def
                     , unicodeBoldStripedS
                     , unicodeBoldHeaderS
                     ]
-    columTs   = [ ( column l p a def
+    columTs   = [ ( column l p a ellipsisCutMark
                   , ["len spec: " ++ dL, "position: " ++ pL, "alignment: " ++ aL]
                   )
                 | (l, dL) <- zip [expand, fixed 10, expandUntil 10, fixedUntil 10]

--- a/src/Text/Layout/Table.hs
+++ b/src/Text/Layout/Table.hs
@@ -19,6 +19,7 @@ module Text.Layout.Table
     , numCol
     , fixedCol
     , fixedLeftCol
+    , defColSpec
       -- ** Length of columns
     , LenSpec
     , expand
@@ -32,6 +33,7 @@ module Text.Layout.Table
     , left
     , right
     , center
+    , beginning
       -- ** Alignment of cells at characters
     , AlignSpec
     , noAlign
@@ -43,6 +45,7 @@ module Text.Layout.Table
     , noCutMark
     , singleCutMark
     , doubleCutMark
+    , ellipsisCutMark
 
       -- * Basic grid layout
     , Row
@@ -80,6 +83,7 @@ module Text.Layout.Table
     , titlesH
     , groupH
     , headerH
+    , defHeaderColSpec
     , zipHeader
     , flattenHeader
     , headerContents
@@ -175,11 +179,11 @@ dotAlign = charAlign '.'
 
 -- | Numbers are positioned on the right and aligned on the floating point dot.
 numCol :: ColSpec
-numCol = column def right dotAlign def
+numCol = column expand right dotAlign ellipsisCutMark
 
 -- | Fixes the column length and positions according to the given 'Position'.
 fixedCol :: Int -> Position H -> ColSpec
-fixedCol l pS = column (fixed l) pS def def
+fixedCol l pS = column (fixed l) pS noAlign ellipsisCutMark
 
 -- | Fixes the column length and positions on the left.
 fixedLeftCol :: Int -> ColSpec
@@ -312,7 +316,7 @@ tableLinesBWithCMIs specs TableStyle { .. } rowHeader colHeader rowGroups =
     -- | Replace the content of a 'HeaderSpec' with the content of the rows or columns to be rendered,
     -- and flatten to a list of content interspersed with column/row separators. If given 'NoneHS', first
     -- replace it with the shape of the data.
-    flattenWithContent (NoneHS sep) content r = flattenHeader . fmap fst . zipHeader mempty r . fullSepH sep (repeat def) $ () <$ content
+    flattenWithContent (NoneHS sep) content r = flattenHeader . fmap fst . zipHeader mempty r . fullSepH sep (repeat defHeaderColSpec) $ () <$ content
     flattenWithContent h            _       r = flattenHeader . fmap fst $ zipHeader mempty r h
 
     -- | Intersperse a row with its rendered separators.

--- a/src/Text/Layout/Table/LineStyle.hs
+++ b/src/Text/Layout/Table/LineStyle.hs
@@ -21,6 +21,7 @@ module Text.Layout.Table.LineStyle
     , unicodeJoinString4
     ) where
 
+import Data.Default.Class (Default(..))
 import Data.Default.Class
 
 -- | The line styles supported by the Unicode Box-Drawing block.

--- a/src/Text/Layout/Table/Pandoc.hs
+++ b/src/Text/Layout/Table/Pandoc.hs
@@ -31,7 +31,7 @@ instance Default PandocSeparator where
 
 -- | Generate a table that is readable but also serves as input to pandoc.
 --
--- >>> mapM_ putStrLn $ pandocPipeTableLines [def, numCol] (titlesH ["text", "numeric value"]) [["a", "1.5"], ["b", "6.60000"]]
+-- >>> mapM_ putStrLn $ pandocPipeTableLines [defColSpec, numCol] (titlesH ["text", "numeric value"]) [["a", "1.5"], ["b", "6.60000"]]
 -- |text|numberic value|
 -- |:---|-------------:|
 -- |a   |       1.5    |

--- a/src/Text/Layout/Table/Spec/ColSpec.hs
+++ b/src/Text/Layout/Table/Spec/ColSpec.hs
@@ -2,9 +2,12 @@ module Text.Layout.Table.Spec.ColSpec
     ( ColSpec
     , lenSpec
     , position
+    , beginning
     , alignSpec
     , cutMark
+    , ellipsisCutMark
     , column
+    , defColSpec
     ) where
 
 import Data.Default.Class
@@ -26,7 +29,13 @@ data ColSpec
     }
 
 instance Default ColSpec where
-    def = column def def def def
+    def = defColSpec
+
+-- | The default 'ColSpec' uses as much space as needed, positioned at the
+-- left/top (depending on orientation), does not align to any character, and
+-- uses a single unicode ellipsis on either side as a cut mark.
+defColSpec :: ColSpec
+defColSpec = column expand beginning noAlign ellipsisCutMark
 
 -- | Smart constructor to specify a column.
 column :: LenSpec -> Position H -> AlignSpec -> CutMark -> ColSpec

--- a/src/Text/Layout/Table/Spec/CutMark.hs
+++ b/src/Text/Layout/Table/Spec/CutMark.hs
@@ -6,6 +6,7 @@ module Text.Layout.Table.Spec.CutMark
     , noCutMark
     , leftMark
     , rightMark
+    , ellipsisCutMark
     ) where
 
 import Data.Default.Class
@@ -20,7 +21,11 @@ data CutMark
 
 -- | A single ellipsis unicode character is used to show cut marks.
 instance Default CutMark where
-    def = singleCutMark "…"
+    def = ellipsisCutMark
+
+-- | The default 'CutMark' is a single ellipsis unicode character on each side.
+ellipsisCutMark :: CutMark
+ellipsisCutMark = singleCutMark "…"
 
 -- | Specify two different cut marks, one for cuts on the left and one for cuts
 -- on the right.

--- a/src/Text/Layout/Table/Spec/HeaderColSpec.hs
+++ b/src/Text/Layout/Table/Spec/HeaderColSpec.hs
@@ -16,4 +16,8 @@ headerColumn = HeaderColSpec
 
 -- | Header columns are usually centered.
 instance Default HeaderColSpec where
-    def = headerColumn center def
+    def = defHeaderColSpec
+
+-- | The default 'HeaderColSpec' centers the text and uses no 'CutMark'.
+defHeaderColSpec :: HeaderColSpec
+defHeaderColSpec = headerColumn center Nothing

--- a/src/Text/Layout/Table/Spec/HeaderSpec.hs
+++ b/src/Text/Layout/Table/Spec/HeaderSpec.hs
@@ -26,7 +26,11 @@ instance Bifunctor HeaderSpec where
 
 -- | By the default the header is not shown.
 instance Default sep => Default (HeaderSpec sep a) where
-    def = NoneHS def
+    def = defHeaderSpec
+
+-- | The default 'HeaderSpec' does not display the header and uses the default separator.
+defHeaderSpec :: Default sep => HeaderSpec sep a
+defHeaderSpec = NoneHS def
 
 -- | Specify no header, with columns separated by a given separator.
 noneSepH :: sep -> HeaderSpec sep String
@@ -46,7 +50,7 @@ fullH = fullSepH def
 
 -- | Use titles with the default header column specification and separator.
 titlesH :: Default sep => [a] -> HeaderSpec sep a
-titlesH = fullH (repeat def)
+titlesH = fullH (repeat defHeaderColSpec)
 
 -- | Use titles with the default header column specification.
 groupH :: sep -> [HeaderSpec sep a] -> HeaderSpec sep a

--- a/src/Text/Layout/Table/Spec/LenSpec.hs
+++ b/src/Text/Layout/Table/Spec/LenSpec.hs
@@ -17,6 +17,7 @@ data LenSpec
     | FixedUntil Int
     | ExpandBetween Int Int
 
+-- | The default 'LenSpec' allows columns to use as much space as needed.
 instance Default LenSpec where
     def = expand
 

--- a/src/Text/Layout/Table/Spec/Position.hs
+++ b/src/Text/Layout/Table/Spec/Position.hs
@@ -23,8 +23,13 @@ instance Show (Position V) where
         Center -> "center"
         End    -> "bottom"
 
+-- | The default 'Position' displays at the left or top, depending on the orientation.
 instance Default (Position orientation) where
-    def = Start
+    def = beginning
+
+-- | Displays at the left or top, depending on the orientation.
+beginning :: Position orientation
+beginning = Start
 
 -- | Horizontal orientation.
 data H


### PR DESCRIPTION
instead of exclusively relying on the Default typeclass

This allows anybody who wants to use the default values without relying
on typeclasses to do so. These more explicit defaults are then used in
code.