### PR TITLE
Allow TableStyle to handle row headers

### DIFF
--- a/src/Test.hs
+++ b/src/Test.hs
@@ -5,7 +5,7 @@ import Text.Layout.Table
 data MySeparator = BigSep | SmallSep | TinySep
 
 inheritMyStyle :: TableStyle LineStyle LineStyle -> TableStyle LineStyle MySeparator
-inheritMyStyle = inheritStyleHeaderGroup id (fst . style) (snd . style)
+inheritMyStyle = inheritStyleHeaderGroup makeLineSolid id (fst . style) (snd . style)
   where
     style BigSep   = (HeavyLine,  HeavyLine)
     style SmallSep = (SingleLine, DashLine)
@@ -27,7 +27,7 @@ main = putStrLn $ tableString [ column (expandUntil 30) left (charAlign ':') def
                             ]
     genTable c s = tableLines (repeat c)
                               s
-                              (noneSepH DashLine)
+                              (fullSepH DashLine (repeat $ headerColumn right Nothing) ["1", "Two"])
                               (groupH BigSep
                                   [ fullSepH SmallSep (repeat def) ["Some text", "Some numbers", "X"]
                                   , groupH SmallSep

--- a/src/Text/Layout/Table/Cell.hs
+++ b/src/Text/Layout/Table/Cell.hs
@@ -37,10 +37,14 @@ class Cell a where
     -- the predicate matches.
     measureAlignment :: (Char -> Bool) -> a -> AlignInfo
 
+    -- | Create an empty cell.
+    -- This should satisfy `buildCell emptyCell = mempty`.
+    emptyCell :: a
+
     -- | Insert the contents into a 'StringBuilder'.
     buildCell :: StringBuilder b => a -> b
 
-    {-# MINIMAL visibleLength, measureAlignment, buildCell, (dropBoth | (dropLeft, dropRight))  #-}
+    {-# MINIMAL visibleLength, measureAlignment, emptyCell, buildCell, (dropBoth | (dropLeft, dropRight))  #-}
 
 instance (Cell a, Cell b) => Cell (Either a b) where
     dropLeft n = bimap (dropLeft n) (dropLeft n)
@@ -48,6 +52,7 @@ instance (Cell a, Cell b) => Cell (Either a b) where
     dropBoth l r = bimap (dropBoth l r) (dropBoth l r)
     visibleLength = either visibleLength visibleLength
     measureAlignment p = either (measureAlignment p) (measureAlignment p)
+    emptyCell = Right emptyCell
     buildCell = either buildCell buildCell
 
 instance Cell String where
@@ -59,6 +64,7 @@ instance Cell String where
             []      -> Nothing
             _ : rs' -> Just $ length rs'
 
+    emptyCell = ""
     buildCell = stringB
 
 instance Cell T.Text where
@@ -70,6 +76,7 @@ instance Cell T.Text where
             then Nothing
             else Just $ T.length rs - 1
 
+    emptyCell = T.pack ""
     buildCell = textB
 
 remSpacesB :: (Cell a, StringBuilder b) => Int -> a -> b

--- a/src/Text/Layout/Table/Cell/Formatted.hs
+++ b/src/Text/Layout/Table/Cell/Formatted.hs
@@ -85,6 +85,7 @@ instance Cell a => Cell (Formatted a) where
     dropRight i = snd . mapAccumR (dropTrackRemaining dropRight) i
     visibleLength = sum . fmap visibleLength
     measureAlignment p = foldl' (mergeAlign p) mempty
+    emptyCell = mempty
     buildCell = cataFormatted mempty mconcat buildCell (\p a s -> stringB p <> a <> stringB s)
 
 -- | Drop characters either from the right or left, while also tracking the

--- a/src/Text/Layout/Table/Cell/WideString.hs
+++ b/src/Text/Layout/Table/Cell/WideString.hs
@@ -12,7 +12,6 @@ import Text.DocLayout
 
 import Text.Layout.Table.Cell
 import Text.Layout.Table.Primitives.AlignInfo
-import Text.Layout.Table.StringBuilder
 
 -- | A newtype for String in which characters can be wider than one space.
 newtype WideString = WideString String
@@ -23,6 +22,7 @@ instance Cell WideString where
     dropRight i (WideString s) = WideString . reverse . dropWide False i $ reverse s
     visibleLength (WideString s) = realLength s
     measureAlignment p (WideString s) = measureAlignmentWide p s
+    emptyCell = WideString ""
     buildCell (WideString s) = buildCell s
 
 -- | Drop characters from the left side of a 'String' until at least the
@@ -55,6 +55,7 @@ instance Cell WideText where
     dropRight i (WideText s) = WideText $ dropRightWideT i s
     visibleLength (WideText s) = realLength s
     measureAlignment p (WideText s) = measureAlignmentWideT p s
+    emptyCell = WideText ""
     buildCell (WideText s) = buildCell s
 
 dropLeftWideT :: Int -> T.Text -> T.Text

--- a/src/Text/Layout/Table/Cell/WideString.hs
+++ b/src/Text/Layout/Table/Cell/WideString.hs
@@ -31,7 +31,7 @@ instance Cell WideString where
 -- The provided `Bool` determines whether to continue dropping zero-width
 -- characters after the requested width has been dropped.
 dropWide :: Bool -> Int -> String -> String
-dropWide _ i [] = []
+dropWide _ _ [] = []
 dropWide gobbleZeroWidth i l@(x : xs)
     | gobbleZeroWidth && i == 0 && charLen == 0 = dropWide gobbleZeroWidth i xs
     | i <= 0       = l

--- a/src/Text/Layout/Table/Primitives/Basic.hs
+++ b/src/Text/Layout/Table/Primitives/Basic.hs
@@ -29,8 +29,6 @@ module Text.Layout.Table.Primitives.Basic
 
 import Text.Layout.Table.Spec.CutMark
 
-import Data.List
-
 spaces :: Int -> String
 spaces = flip replicate ' '
 

--- a/src/Text/Layout/Table/Primitives/Table.hs
+++ b/src/Text/Layout/Table/Primitives/Table.hs
@@ -6,9 +6,6 @@ module Text.Layout.Table.Primitives.Table
     , horizontalContentLine
     ) where
 
-import           Data.Either
-import           Data.List
-
 import           Text.Layout.Table.StringBuilder
 import           Text.Layout.Table.Spec.Util
 
@@ -17,19 +14,27 @@ import           Text.Layout.Table.Spec.Util
 -- the content appropriately and visually separate by 'hSpace'.
 horizontalDetailLine
     :: StringBuilder b
-    => String                 -- ^ The space characters that are used as padding.
-    -> String                 -- ^ The delimiter that is used on the left side.
-    -> String                 -- ^ The delimiter that is used on the right side.
-    -> Row (Either String b)  -- ^ A row of builders and separators.
-    -> b                      -- ^ The formatted line as a 'StringBuilder'.
-horizontalDetailLine hSpace delimL delimR cells = mconcat . intersperse (stringB hSpace) $
-    stringB delimL : map (either stringB id) cells ++ [stringB delimR]
+    => String                            -- ^ The space characters that are used as padding.
+    -> String                            -- ^ The space characters that are used as padding in the row header.
+    -> String                            -- ^ The delimiter that is used on the left side.
+    -> String                            -- ^ The delimiter that is used on the right side.
+    -> String                            -- ^ The delimiter that is used for the row header separator.
+    -> (Maybe b, Row (Either String b))  -- ^ Optionally a row header, along with a row of builders and separators.
+    -> b                                 -- ^ The formatted line as a 'StringBuilder'.
+horizontalDetailLine hSpace hSepSpace delimL delimR delimSep (header, cells) =
+    stringB delimL <> renderedHeader <> renderedCells <> stringB delimR
+  where
+    renderedHeader = case header of
+      Nothing -> mempty
+      Just r  -> stringB hSepSpace <> r <> stringB hSepSpace <> stringB delimSep
+    renderedCells = foldMap ((stringB hSpace <>) . either stringB id) cells <> stringB hSpace
 
 -- | Render a line with actual content.
 horizontalContentLine
     :: StringBuilder b
-    => String                 -- ^ The delimiter that is used on the left side.
-    -> String                 -- ^ The delimiter that is used on the right side.
-    -> Row (Either String b)  -- ^ A row of builders and separators.
+    => String                            -- ^ The delimiter that is used on the left side.
+    -> String                            -- ^ The delimiter that is used on the right side.
+    -> String                            -- ^ The delimiter that is used on the row header separator.
+    -> (Maybe b, Row (Either String b))  -- ^ A row of builders and separators.
     -> b
-horizontalContentLine = horizontalDetailLine " "
+horizontalContentLine = horizontalDetailLine " " " "

--- a/src/Text/Layout/Table/Spec/HeaderSpec.hs
+++ b/src/Text/Layout/Table/Spec/HeaderSpec.hs
@@ -5,9 +5,7 @@ module Text.Layout.Table.Spec.HeaderSpec where
 import Data.Bifunctor
 import Data.Default.Class
 import Data.List
-import Data.Maybe
 
-import Text.Layout.Table.LineStyle
 import Text.Layout.Table.Spec.HeaderColSpec
 
 -- | Specifies a header.

--- a/src/Text/Layout/Table/Style.hs
+++ b/src/Text/Layout/Table/Style.hs
@@ -43,8 +43,6 @@ module Text.Layout.Table.Style
     , TableStyle(..)
     ) where
 
-import Data.Function (on)
-
 import Text.Layout.Table.LineStyle
 
 -- | Specifies the different letters to construct the non-content structure of a

--- a/src/Text/Layout/Table/Vertical.hs
+++ b/src/Text/Layout/Table/Vertical.hs
@@ -10,6 +10,7 @@ module Text.Layout.Table.Vertical
 
 import Data.List
 
+import Text.Layout.Table.Cell
 import Text.Layout.Table.Spec.Position
 import Text.Layout.Table.Spec.Util
 import Text.Layout.Table.Primitives.Basic
@@ -21,8 +22,8 @@ import Text.Layout.Table.Primitives.Basic
 
 The result is intended to be used with a grid layout function like 'Text.Layout.Table.grid'.
 -}
-colsAsRowsAll :: Monoid a => Position V -> [Col a] -> [Row a]
-colsAsRowsAll ps = transpose . vPadAll mempty ps
+colsAsRowsAll :: Cell a => Position V -> [Col a] -> [Row a]
+colsAsRowsAll ps = transpose . vPadAll emptyCell ps
 
 {- | Works like 'colsAsRowsAll' but every position can be specified on its
    own:
@@ -30,8 +31,8 @@ colsAsRowsAll ps = transpose . vPadAll mempty ps
 >>> colsAsRows [top, center, bottom] [["a1"], ["b1", "b2", "b3"], ["c3"]]
 [["a1","b1",""],["","b2",""],["","b3","c3"]]
 -}
-colsAsRows :: Monoid a => [Position V] -> [Col a] -> [Row a]
-colsAsRows ps = transpose . vPad mempty ps
+colsAsRows :: Cell a => [Position V] -> [Col a] -> [Row a]
+colsAsRows ps = transpose . vPad emptyCell ps
 
 -- | Fill all columns to the same length by aligning at the given position.
 vPadAll :: a -> Position V -> [Col a] -> [Col a]


### PR DESCRIPTION
This addresses some of the points in https://github.com/muesli4/table-layout/issues/20#issuecomment-1060164646. In particular, row headers are now rendered in the table, along with special line styles available within the row header (as there are in the column headers).

I have chosen to display a row header only in the first line of a row group, thus breaking the symmetry between row groups and row headers, so that question has also been resolved.

Also simplifies the creation of new TableStyle from TableStyleSpec, allowing it to handle ASCII tables as well, and creating an even simpler constructor simpleTableStyleSpec.