### PR TITLE
Improve trimming and behaviour of some LenSpec

### DIFF
--- a/src/Text/Layout/Table.hs
+++ b/src/Text/Layout/Table.hs
@@ -108,6 +108,7 @@ module Text.Layout.Table
 
       -- * Column modification functions
     , pad
+    , trim
     , trimOrPad
     , align
     , alignFixed

--- a/src/Text/Layout/Table.hs
+++ b/src/Text/Layout/Table.hs
@@ -24,6 +24,7 @@ module Text.Layout.Table
     , fixed
     , expandUntil
     , fixedUntil
+    , expandBetween
       -- ** Positional alignment
     , Position
     , H
@@ -110,6 +111,7 @@ module Text.Layout.Table
     , pad
     , trim
     , trimOrPad
+    , trimOrPadBetween
     , align
     , alignFixed
 

--- a/src/Text/Layout/Table/Cell.hs
+++ b/src/Text/Layout/Table/Cell.hs
@@ -157,28 +157,29 @@ trimOrPadBetween p cm s l c
   where
     k = visibleLength c
 
--- | Trim a cell based on the position.
+-- | Trim a cell based on the position. Cut marks may be trimmed if necessary.
 trim :: (Cell a, StringBuilder b) => Position o -> CutMark -> Int -> a -> b
 trim p cm n c = if k <= n then buildCell c else trim' p cm n k c
   where
     k = visibleLength c
 
--- | Trim a cell based on the position. Preconditions that require to be met
--- (otherwise the function will produce garbage):
+-- | Trim a cell based on the position. Cut marks may be trimmed if necessary.
+--
+-- Preconditions that require to be met (otherwise the function will produce garbage):
 -- prop> visibleLength c > n
 -- prop> visibleLength c == k
 trim' :: (Cell a, StringBuilder b) => Position o -> CutMark -> Int -> Int -> a -> b
 trim' p cm n k c = case p of
-    Start  -> buildCell (dropRight (cutLen + rightLen) c) <> buildCell (rightMark cm)
+    Start  -> buildCell (dropRight (cutLen + rightLen) c) <> buildCell (drop (rightLen - n) $ rightMark cm)
     Center -> case cutLen `divMod` 2 of
-        (0, 1) -> buildCell (leftMark cm) <> buildCell (dropLeft (1 + leftLen) c)
-        (q, r) -> if n > leftLen + rightLen
+        (0, 1) -> buildCell (take n $ leftMark cm) <> buildCell (dropLeft (1 + leftLen) c)
+        (q, r) -> if n >= leftLen + rightLen
                   then buildCell (leftMark cm) <> buildCell (dropBoth (leftLen + q + r) (rightLen + q) c)
                        <> buildCell (rightMark cm)
                   else case n `divMod` 2 of
                       (qn, rn) -> buildCell (take qn $ leftMark cm)
                                   <> buildCell (drop (rightLen - qn - rn) $ rightMark cm)
-    End    -> buildCell (leftMark cm) <> buildCell (dropLeft (leftLen + cutLen) c)
+    End    -> buildCell (take n $ leftMark cm) <> buildCell (dropLeft (leftLen + cutLen) c)
   where
     leftLen = length $ leftMark cm
     rightLen = length $ rightMark cm

--- a/src/Text/Layout/Table/Cell.hs
+++ b/src/Text/Layout/Table/Cell.hs
@@ -143,6 +143,20 @@ trimOrPad p cm n c = case compare k n of
   where
     k = visibleLength c
 
+-- | If the given text is longer than the second 'Int' argument, it will be
+-- trimmed to that length according to the position specification. Adds cut
+-- marks to indicate that the column has been trimmed in length. Otherwise, if
+-- it is shorter than the first 'Int' argument, it will be padded to that
+-- length.
+--
+trimOrPadBetween :: (Cell a, StringBuilder b) => Position o -> CutMark -> Int -> Int -> a -> b
+trimOrPadBetween p cm s l c
+    | k > l     = trim' p cm l k c
+    | k < s     = pad' p s k c
+    | otherwise = buildCell c
+  where
+    k = visibleLength c
+
 -- | Trim a cell based on the position.
 trim :: (Cell a, StringBuilder b) => Position o -> CutMark -> Int -> a -> b
 trim p cm n c = if k <= n then buildCell c else trim' p cm n k c

--- a/src/Text/Layout/Table/Primitives/ColumnModifier.hs
+++ b/src/Text/Layout/Table/Primitives/ColumnModifier.hs
@@ -102,22 +102,30 @@ deriveColModInfos specs = zipWith ($) (fmap fSel specs) . transpose
                            expandUntil' f i max' = if f (max' <= i)
                                                    then FillTo max'
                                                    else fitTo i max'
+                           expandBetween' i j max' | max' > j  = fitTo j max'
+                                                   | max' < i  = fitTo i max'
+                                                   | otherwise = FillTo max'
                            fun                  = case lenS of
-                               Expand        -> FillTo
-                               Fixed i       -> fitTo i
-                               ExpandUntil i -> expandUntil' id i
-                               FixedUntil i  -> expandUntil' not i
+                               Expand            -> FillTo
+                               Fixed i           -> fitTo i
+                               ExpandUntil i     -> expandUntil' id i
+                               FixedUntil i      -> expandUntil' not i
+                               ExpandBetween i j -> expandBetween' i j
                        in fun . maximum . map visibleLength
         AlignOcc oS -> let fitToAligned i      = FitTo i . Just . (,) oS
                            fillAligned         = FillAligned oS
                            expandUntil' f i ai = if f (widthAI ai <= i)
                                                 then fillAligned ai
                                                 else fitToAligned i ai
+                           expandBetween' i j ai | widthAI ai > j = fitToAligned j ai
+                                                 | widthAI ai < i = fitToAligned i ai
+                                                 | otherwise      = fillAligned ai
                            fun                = case lenS of
-                               Expand        -> fillAligned
-                               Fixed i       -> fitToAligned i
-                               ExpandUntil i -> expandUntil' id i
-                               FixedUntil i  -> expandUntil' not i
+                               Expand            -> fillAligned
+                               Fixed i           -> fitToAligned i
+                               ExpandUntil i     -> expandUntil' id i
+                               FixedUntil i      -> expandUntil' not i
+                               ExpandBetween i j -> expandBetween' i j
                         in fun . foldMap (deriveAlignInfo oS)
 
 deriveColModInfos' :: Cell a => [ColSpec] -> [Row a] -> [ColModInfo]

--- a/src/Text/Layout/Table/Spec/CutMark.hs
+++ b/src/Text/Layout/Table/Spec/CutMark.hs
@@ -16,7 +16,7 @@ data CutMark
     = CutMark
     { leftMark  :: String
     , rightMark :: String
-    }
+    } deriving (Show, Eq)
 
 -- | A single ellipsis unicode character is used to show cut marks.
 instance Default CutMark where

--- a/src/Text/Layout/Table/Spec/LenSpec.hs
+++ b/src/Text/Layout/Table/Spec/LenSpec.hs
@@ -4,6 +4,7 @@ module Text.Layout.Table.Spec.LenSpec
     , fixed
     , expandUntil
     , fixedUntil
+    , expandBetween
     ) where
 
 import Data.Default.Class
@@ -14,6 +15,7 @@ data LenSpec
     | Fixed Int
     | ExpandUntil Int
     | FixedUntil Int
+    | ExpandBetween Int Int
 
 instance Default LenSpec where
     def = expand
@@ -33,3 +35,8 @@ expandUntil = ExpandUntil
 -- | The column will be at least as wide as the given width.
 fixedUntil :: Int -> LenSpec
 fixedUntil = FixedUntil
+
+-- | The column will be at least as wide as the first width, and will expand as
+-- long as it is smaller than the second.
+expandBetween :: Int -> Int -> LenSpec
+expandBetween = ExpandBetween


### PR DESCRIPTION
The trim function will no longer produce garbage if given a length that
is longer than the Cell to trim. Previously the only way to safely trim
was with the trimOrPad function, which would also pad if the Cell was
too short. This new function avoids this possibly unwanted effect.

We also provide unsafe helper versions of the pad and fill functions
which take the visibleLength of the Cell as an argument, ensuring that
visibleLength is never calculated more than once.