### PR TITLE
Use default instances for separators

### DIFF
--- a/src/Text/Layout/Table/LineStyle.hs
+++ b/src/Text/Layout/Table/LineStyle.hs
@@ -19,6 +19,7 @@ module Text.Layout.Table.LineStyle
     ) where
 
 import Data.Function (on)
+import Data.Default.Class
 
 -- | The line styles supported by the Unicode Box-Drawing block.
 data LineStyle
@@ -33,6 +34,10 @@ data LineStyle
     | Dash2Line       -- | @╌@ and @╎@.
     | HeavyDash2Line  -- | @╍@ and @╏@.
   deriving (Eq)
+
+instance Default LineStyle where
+    -- | A single line.
+    def = SingleLine
 
 -- | Make a 'LineStyle' bold.
 makeLineBold :: LineStyle -> LineStyle

--- a/src/Text/Layout/Table/Pandoc.hs
+++ b/src/Text/Layout/Table/Pandoc.hs
@@ -1,9 +1,14 @@
 -- | Render tables that can be used in <https://pandoc.org/ Pandoc>. In
 -- particular, this supports the
 -- <https://pandoc.org/MANUAL.html#tables pipe_tables> extension.
-module Text.Layout.Table.Pandoc where
+module Text.Layout.Table.Pandoc
+  ( PandocSeparator
+  , pandocPipeTableLines
+  ) where
 
 import Data.List
+
+import Data.Default.Class
 
 import Text.Layout.Table.Cell
 import Text.Layout.Table.Primitives.ColumnModifier
@@ -12,6 +17,17 @@ import Text.Layout.Table.Spec.ColSpec
 import Text.Layout.Table.Spec.HeaderSpec
 import Text.Layout.Table.Spec.Position
 import Text.Layout.Table.Spec.Util
+
+-- | The separator to be used for 'HeaderSpec'.  The only supported value is
+-- 'def'.  Typically, it is not necessary to use this.
+data PandocSeparator
+    -- The value is not actually used anywhere.  It exists with the sole
+    -- purpose to limit user input to the single supported character.
+    = PandocSeparator
+
+instance Default PandocSeparator where
+    -- | A single line represented by @-@ and @|@.
+    def = PandocSeparator
 
 -- | Generate a table that is readable but also serves as input to pandoc.
 --
@@ -23,7 +39,7 @@ import Text.Layout.Table.Spec.Util
 pandocPipeTableLines
     :: Cell c
     => [ColSpec]
-    -> HeaderSpec vSep c
+    -> HeaderSpec PandocSeparator c
     -> [Row String]
     -> [String]
 pandocPipeTableLines specs h tab =

--- a/src/Text/Layout/Table/Spec/HeaderSpec.hs
+++ b/src/Text/Layout/Table/Spec/HeaderSpec.hs
@@ -35,19 +35,19 @@ noneSepH :: sep -> HeaderSpec sep String
 noneSepH = NoneHS
 
 -- | Specify no header, with columns separated by a default separator.
-noneH :: HeaderSpec LineStyle String
-noneH = noneSepH SingleLine
+noneH :: Default sep => HeaderSpec sep String
+noneH = noneSepH def
 
 -- | Specify a header column for every title, with a given separator.
 fullSepH :: sep -> [HeaderColSpec] -> [a] -> HeaderSpec sep a
 fullSepH sep specs = GroupHS sep . zipWith HeaderHS specs
 
 -- | Specify a header column for every title, with a default separator.
-fullH :: [HeaderColSpec] -> [a] -> HeaderSpec LineStyle a
-fullH = fullSepH SingleLine
+fullH :: Default sep => [HeaderColSpec] -> [a] -> HeaderSpec sep a
+fullH = fullSepH def
 
 -- | Use titles with the default header column specification and separator.
-titlesH :: [a] -> HeaderSpec LineStyle a
+titlesH :: Default sep => [a] -> HeaderSpec sep a
 titlesH = fullH (repeat def)
 
 -- | Use titles with the default header column specification.


### PR DESCRIPTION
* Provide Default instances for separators.
* Limit separators for Pandoc tables.

I wrote this a while ago to lift the restriction on the separator type for `fullH` and `titlesH`.