### PR TITLE
Make Cell lazier to allow more instances

### DIFF
--- a/src/Text/Layout/Table.hs
+++ b/src/Text/Layout/Table.hs
@@ -115,6 +115,7 @@ module Text.Layout.Table
     , trimOrPadBetween
     , align
     , alignFixed
+    , adjustCell
 
       -- * Column modifaction primitives
       -- | These functions are provided to be reused. For example if someone

--- a/src/Text/Layout/Table/Cell/WideString.hs
+++ b/src/Text/Layout/Table/Cell/WideString.hs
@@ -18,12 +18,14 @@ newtype WideString = WideString String
     deriving (Eq, Ord, Show, Read, Semigroup, Monoid, IsString)
 
 instance Cell WideString where
-    dropLeft i (WideString s) = WideString $ dropWide True i s
-    dropRight i (WideString s) = WideString . reverse . dropWide False i $ reverse s
     visibleLength (WideString s) = realLength s
     measureAlignment p (WideString s) = measureAlignmentWide p s
     emptyCell = WideString ""
     buildCell (WideString s) = buildCell s
+    buildCellView = buildCellViewLRHelper
+      (\(WideString s) -> buildCell s)
+      (\i (WideString s) -> WideString $ dropWide True i s)
+      (\i (WideString s) -> WideString . reverse . dropWide False i $ reverse s)
 
 -- | Drop characters from the left side of a 'String' until at least the
 -- provided width has been removed.
@@ -51,12 +53,14 @@ newtype WideText = WideText T.Text
     deriving (Eq, Ord, Show, Read, Semigroup, Monoid, IsString)
 
 instance Cell WideText where
-    dropLeft i (WideText s) = WideText $ dropLeftWideT i s
-    dropRight i (WideText s) = WideText $ dropRightWideT i s
     visibleLength (WideText s) = realLength s
     measureAlignment p (WideText s) = measureAlignmentWideT p s
     emptyCell = WideText ""
     buildCell (WideText s) = buildCell s
+    buildCellView = buildCellViewLRHelper
+        (\(WideText s) -> buildCell s)
+        (\i (WideText s) -> WideText $ dropLeftWideT i s)
+        (\i (WideText s) -> WideText $ dropRightWideT i s)
 
 dropLeftWideT :: Int -> T.Text -> T.Text
 dropLeftWideT i txt = case T.uncons txt of

--- a/test-suite/TestSpec.hs
+++ b/test-suite/TestSpec.hs
@@ -14,7 +14,7 @@ import Test.Hspec.QuickCheck
 import Test.QuickCheck
 
 import Text.Layout.Table
-import Text.Layout.Table.Cell (Cell(..), CutAction(..), CutInfo(..), applyCutInfo, determineCutAction, determineCuts, viewRange)
+import Text.Layout.Table.Cell (Cell(..), CutAction(..), CutInfo(..), applyCutInfo, determineCutAction, determineCuts, dropLeft, dropRight, viewRange)
 import Text.Layout.Table.Cell.WideString (WideString(..), WideText(..))
 import Text.Layout.Table.Spec.AlignSpec
 import Text.Layout.Table.Spec.CutMark
@@ -304,21 +304,21 @@ spec = do
             it "detects zero width after" $ measureAlignmentAt 'n' narrow `shouldBe` AlignInfo 3 (Just 5)
             it "detects zero width before" $ measureAlignmentAt 'r' narrow `shouldBe` AlignInfo 7 (Just 1)
         describe "dropLeft" $ do
-            prop "agrees for ascii strings" $ \(Small n) (NonControlASCIIString x) -> buildCell (dropLeft n (WideString x)) `shouldBe` dropLeft n x
+            prop "agrees for ascii strings" $ \(Small n) (NonControlASCIIString x) -> buildCell (dropLeft n (WideString x)) `shouldBe` (buildCell (dropLeft n x) :: String)
             describe "on wide characters" $ do
-                it "drops 1 character of double width" $ dropLeft 2 wide `shouldBe` WideString "㐁㐂"
-                it "drops 2 characters of double width and adds a space" $ dropLeft 3 wide `shouldBe` WideString " 㐂"
+                it "drops 1 character of double width" $ buildCell (dropLeft 2 wide) `shouldBe` "㐁㐂"
+                it "drops 2 characters of double width and adds a space" $ buildCell (dropLeft 3 wide) `shouldBe` " 㐂"
             describe "on narrow characters" $ do
-                it "drops combining characters with their previous" $ dropLeft 7 narrow `shouldBe` WideString "r!"
-                it "drops combining characters after a dropped wide character which overshoots" $ dropLeft 1 (WideString "㐀̈㐁") `shouldBe` WideString " 㐁"
+                it "drops combining characters with their previous" $ buildCell (dropLeft 7 narrow) `shouldBe` "r!"
+                it "drops combining characters after a dropped wide character which overshoots" $ buildCell (dropLeft 1 (WideString "㐀̈㐁")) `shouldBe` " 㐁"
         describe "dropRight" $ do
-            prop "agrees for ascii strings" $ \(Small n) (NonControlASCIIString x) -> buildCell (dropRight n (WideString x)) `shouldBe` dropRight n x
+            prop "agrees for ascii strings" $ \(Small n) (NonControlASCIIString x) -> buildCell (dropRight n (WideString x)) `shouldBe` (buildCell (dropRight n x) :: String)
             describe "on wide characters" $ do
-                it "drops 1 character of double width" $ dropRight 2 wide `shouldBe` WideString "㐀㐁"
-                it "drops 2 characters of double width and adds a space" $ dropRight 3 wide `shouldBe` WideString "㐀 "
+                it "drops 1 character of double width" $ buildCell (dropRight 2 wide) `shouldBe` "㐀㐁"
+                it "drops 2 characters of double width and adds a space" $ buildCell (dropRight 3 wide) `shouldBe` "㐀 "
             describe "on narrow characters" $ do
-                it "drops a combining character for free" $ dropRight 3 narrow `shouldBe` WideString "Bien s"
-                it "does not drop a combining character without their previous" $ dropRight 2 narrow `shouldBe` WideString "Bien sû"
+                it "drops a combining character for free" $ buildCell (dropRight 3 narrow) `shouldBe` "Bien s"
+                it "does not drop a combining character without their previous" $ buildCell (dropRight 2 narrow) `shouldBe` "Bien sû"
 
     describe "wide text" $ do
         describe "buildCell" $ do


### PR DESCRIPTION
Previously Cell required being able to drop from the left or right without changing the type of the object. This made it awkward to define instances for which this was not natural.

Cell will no longer drop from the left or right immediately. Instead, drop(Left|Right|Both) will record the amount that has been requested to be dropped, and drop it when buildCell is called.

Changes to the API require that instance declarations for Cell be changed as follows:

1.
instance Cell a where
  dropLeft = f
  dropRight = g
  ...

can be changed to

instance Cell a where
  buildCellView = buildCellViewLRHelper buildCell f g
  ...

2.
instance Cell a where
  dropBoth = f
  ...

can be changed to

instance Cell a where
  buildCellView = buildCellViewBothHelper buildCell f
  ...

3.
instance Cell a where
  dropLeft = f
  dropRight = g
  dropBoth = h
  ...

can be changed to

instance Cell a where
  buildCellView = buildCellViewHelper buildCell buildCell buildCell f g h
  ...

Since dropLeft, dropRight, and dropBoth are no longer class methods of Cell, they may need to be imported explicitly. Code which relies on dropLeft, dropRight, and dropBoth not changing the type of the output may need to be rewritten, possibly by calling buildCell on the result.