### PR TITLE
Remove emptyCell (#45)

### DIFF
--- a/src/Text/Layout/Table/Cell/Formatted.hs
+++ b/src/Text/Layout/Table/Cell/Formatted.hs
@@ -84,7 +84,6 @@ instance Monoid (Formatted a) where
 instance Cell a => Cell (Formatted a) where
     visibleLength = sum . fmap visibleLength
     measureAlignment p = foldl' (mergeAlign p) mempty
-    emptyCell = plain emptyCell
     buildCell = buildFormatted buildCell
     buildCellView = buildCellViewHelper
         (buildFormatted buildCell)

--- a/src/Text/Layout/Table/Cell/WideString.hs
+++ b/src/Text/Layout/Table/Cell/WideString.hs
@@ -20,7 +20,6 @@ newtype WideString = WideString String
 instance Cell WideString where
     visibleLength (WideString s) = realLength s
     measureAlignment p (WideString s) = measureAlignmentWide p s
-    emptyCell = WideString ""
     buildCell (WideString s) = buildCell s
     buildCellView = buildCellViewLRHelper
       (\(WideString s) -> buildCell s)
@@ -55,7 +54,6 @@ newtype WideText = WideText T.Text
 instance Cell WideText where
     visibleLength (WideText s) = realLength s
     measureAlignment p (WideText s) = measureAlignmentWideT p s
-    emptyCell = WideText ""
     buildCell (WideText s) = buildCell s
     buildCellView = buildCellViewLRHelper
         (\(WideText s) -> buildCell s)

--- a/src/Text/Layout/Table/Spec/RowGroup.hs
+++ b/src/Text/Layout/Table/Spec/RowGroup.hs
@@ -40,9 +40,9 @@ data ColumnSegment a
     = SingleValueSegment a
     | ColumnSegment (Col a)
     | NullableColumnSegment (Col (Maybe a))
-    deriving (Functor, Foldable, Show)
+    deriving (Functor, Foldable, Eq, Show)
 
-newtype SegmentedColumn a = SegmentedColumn [ColumnSegment a] deriving (Functor, Foldable, Show)
+newtype SegmentedColumn a = SegmentedColumn [ColumnSegment a] deriving (Functor, Foldable, Eq, Show)
 
 -- | Break down several 'RowGroups', which conceptually form a column by
 -- themselves, into a list of columns.

--- a/src/Text/Layout/Table/Spec/RowGroup.hs
+++ b/src/Text/Layout/Table/Spec/RowGroup.hs
@@ -1,18 +1,61 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveFoldable #-}
 module Text.Layout.Table.Spec.RowGroup where
 
 import Text.Layout.Table.Spec.Util
 
+import Data.List (transpose)
+import Data.Functor (void)
+
 -- | Groups rows together which should not be visually seperated from each other.
-newtype RowGroup a
-    = RowGroup
-    { rows :: [Row a]
-    }
+data RowGroup a
+    = MultiRowGroup [Row a]
+    | NullableRowGroup [Row (Maybe a)]
 
 -- | Group the given rows together.
 rowsG :: [Row a] -> RowGroup a
-rowsG = RowGroup
+rowsG = MultiRowGroup
 
 -- | Make a group of a single row.
 rowG :: Row a -> RowGroup a
-rowG = RowGroup . (: [])
+rowG = MultiRowGroup . (: [])
 
+-- | Provide a 'RowGroup' where single cells may be missing.
+nullableRowsG :: [Row (Maybe a)] -> RowGroup a
+nullableRowsG = NullableRowGroup
+
+-- | Extracts the shape of the 'RowGroup' from the first row.
+rowGroupShape :: RowGroup a -> [()]
+rowGroupShape rg = case rg of
+    MultiRowGroup rs     -> firstSubListShape rs
+    NullableRowGroup ors -> firstSubListShape ors
+  where
+    firstSubListShape l = case l of
+        r : _ -> void r
+        []    -> []
+
+data ColumnSegment a
+    = ColumnSegment (Col a)
+    | NullableColumnSegment (Col (Maybe a))
+    deriving (Functor, Foldable, Show)
+
+newtype SegmentedColumn a = SegmentedColumn [ColumnSegment a] deriving (Functor, Foldable, Show)
+
+-- | Break down several 'RowGroups', which conceptually form a column by
+-- themselves, into a list of columns.
+transposeRowGroups :: Col (RowGroup a) -> [SegmentedColumn a]
+transposeRowGroups = fmap SegmentedColumn . transpose . map transposeRowGroup
+  where
+    transposeRowGroup :: RowGroup a -> [ColumnSegment a]
+    transposeRowGroup rg = case rg of
+        MultiRowGroup rows    -> ColumnSegment <$> transpose rows
+        NullableRowGroup rows -> NullableColumnSegment <$> transpose rows
+
+-- | Map each column with the corresponding function and replace empty inputs
+-- with the given value.
+mapRowGroupColumns :: [(b, (a -> b))] -> RowGroup a -> [[b]]
+mapRowGroupColumns mappers rg = case rg of
+    MultiRowGroup rows     -> mapGrid snd rows
+    NullableRowGroup orows -> mapGrid (uncurry maybe) orows
+  where
+    mapGrid applyMapper = map $ zipWith applyMapper mappers

--- a/src/Text/Layout/Table/Vertical.hs
+++ b/src/Text/Layout/Table/Vertical.hs
@@ -18,21 +18,21 @@ import Text.Layout.Table.Primitives.Basic
 {- | Merges multiple columns together to a valid grid without holes. For example:
 
 >>> colsAsRowsAll top [justifyText 10 "This text will not fit on one line.", ["42", "23"]]
-[["This  text","42"],["will   not","23"],["fit on one",""],["line.",""]]
+[[Just "This  text",Just "42"],[Just "will   not",Just "23"],[Just "fit on one",Nothing],[Just "line.",Nothing]]
 
 The result is intended to be used with a grid layout function like 'Text.Layout.Table.grid'.
 -}
-colsAsRowsAll :: Cell a => Position V -> [Col a] -> [Row a]
-colsAsRowsAll ps = transpose . vPadAll emptyCell ps
+colsAsRowsAll :: Position V -> [Col a] -> [Row (Maybe a)]
+colsAsRowsAll p = transpose . vPadAll Nothing p . fmap (fmap Just)
 
 {- | Works like 'colsAsRowsAll' but every position can be specified on its
    own:
 
 >>> colsAsRows [top, center, bottom] [["a1"], ["b1", "b2", "b3"], ["c3"]]
-[["a1","b1",""],["","b2",""],["","b3","c3"]]
+[[Just "a1",Just "b1",Nothing],[Nothing,Just "b2",Nothing],[Nothing,Just "b3",Just "c3"]]
 -}
-colsAsRows :: Cell a => [Position V] -> [Col a] -> [Row a]
-colsAsRows ps = transpose . vPad emptyCell ps
+colsAsRows :: [Position V] -> [Col a] -> [Row (Maybe a)]
+colsAsRows ps = transpose . vPad Nothing ps . fmap (fmap Just)
 
 -- | Fill all columns to the same length by aligning at the given position.
 vPadAll :: a -> Position V -> [Col a] -> [Col a]


### PR DESCRIPTION
Removes `emptyCell` and implements the empty cell for table headers on a lower level.

## Testing done

The tests pass and the executable works as expected.