### PR TITLE
Restore rounded ASCII style

### DIFF
--- a/src/Text/Layout/Table/LineStyle.hs
+++ b/src/Text/Layout/Table/LineStyle.hs
@@ -149,6 +149,11 @@ arJoins _          _          NoLine     _          = "."
 -- Bottom joins
 arJoins _          _          DoubleLine NoLine     = "''"
 arJoins _          _          _          NoLine     = "'"
+-- T-joins
+arJoins NoLine     _          SingleLine SingleLine = ":"
+arJoins _          NoLine     SingleLine SingleLine = ":"
+arJoins NoLine     _          DoubleLine DoubleLine = "::"
+arJoins _          NoLine     DoubleLine DoubleLine = "::"
 -- Left joins
 arJoins NoLine     DoubleLine DoubleLine _          = "::"
 arJoins NoLine     DoubleLine _          _          = ":"


### PR DESCRIPTION
Do not use + on the outside of the table.

## Testing done

```
> putStrLn $ tableString [def, def] (roundedAsciiTableStyleFromSpec $ simpleTableStyleSpec SingleLine SingleLine) (titlesH ["row a", "row b"]) (titlesH ["col a", "col b"]) [rowG ["a", "b"], rowG ["c", "d"]]
.-------.-------.-------.
|       | col a | col b |
:-------+-------+-------:
| row a | a     | b     |
:-------+-------+-------:
| row b | c     | d     |
'-------'-------'-------'
```
I also went through some other rounded styles with and without header.  I did not see any issues.